### PR TITLE
Route console messages to stderr and transcription to stdout

### DIFF
--- a/hns/cli.py
+++ b/hns/cli.py
@@ -16,7 +16,8 @@ from rich.live import Live
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from rich.text import Text
 
-console = Console()
+console = Console(stderr=True)
+stdout_console = Console()
 
 
 def format_duration(seconds: float) -> str:
@@ -250,6 +251,7 @@ class WhisperTranscriber:
                     TextColumn("[bold blue]Processing audio..."),
                     TimeElapsedColumn(),
                     transient=False,
+                    console=console,
                 ) as progress:
                     task = progress.add_task("Analyzing speech patterns", total=None)
 
@@ -311,7 +313,7 @@ def copy_to_clipboard(text: str, elapsed_time: Optional[float] = None):
         console.print(f"✅ [bold green]Transcribed and copied to clipboard in {elapsed_time:.1f}s![/bold green]")
     else:
         console.print("✅ [bold green]Transcribed and copied to clipboard![/bold green]")
-    console.print(f"\n{text}")
+    stdout_console.print(text)
 
 
 @click.command()


### PR DESCRIPTION
 ## Summary
  - Modified console output routing to separate user feedback from transcription results
  - Status messages, progress indicators, and notifications now go to stderr
  - Transcription text output remains on stdout for clean piping

  ## Changes
  - Split Console instances: main console routes to stderr, stdout_console for transcription
  - Updated Progress component to use stderr console
  - Changed transcription output to use stdout_console

  ## Benefits
  - Enables clean piping of transcription results: `hns > output.txt`
  - Preserves user feedback and status messages on terminal
  - Follows Unix convention of separating data from diagnostic messages