### PR TITLE
lazy import faster_whisper

### DIFF
--- a/hns/cli.py
+++ b/hns/cli.py
@@ -10,7 +10,6 @@ import click
 import numpy as np
 import pyperclip
 import sounddevice as sd
-from faster_whisper import WhisperModel
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
@@ -187,7 +186,9 @@ class WhisperTranscriber:
 
         return model
 
-    def _load_model(self) -> WhisperModel:
+    def _load_model(self):
+        from faster_whisper import WhisperModel
+
         try:
             return WhisperModel(self.model_name, device="cpu", compute_type="int8")
         except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hns"
-version = "1.0.5"
+version = "1.0.6"
 description = "A simple, privacy-focused speech-to-text CLI tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -304,7 +304,7 @@ wheels = [
 
 [[package]]
 name = "hns"
-version = "1.0.5"
+version = "1.0.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

lazy import faster_whisper

## Why

for quicker startup time of the tool. Profile the imports and faster_whisper was taking the majority of the import time

```
==================================================
DETAILED IMPORT TIMES
==================================================
faster_whisper.WhisperModel      0.3309s ( 61.2%)
numpy (as np)                    0.0682s ( 12.6%)
sounddevice (as sd)              0.0681s ( 12.6%)
rich (all)                       0.0442s (  8.2%)
click                            0.0140s (  2.6%)
pyperclip                        0.0049s (  0.9%)
wave                             0.0025s (  0.5%)
time                             0.0000s (  0.0%)
--------------------------------------------------
TOTAL                            0.5409s
==================================================
```